### PR TITLE
Apply standard Python project layout

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+Copyright (c) 2021 Robert J. Moerland, LUMICKS B.V.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.* LICENSE.* setup.cfg setup.py *.toml
+graft src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
 # py-optics
+
 Python code to aid with calculations for nanophotonics. Currently it contains:
-- fast_psf_calc: code that calculates the point spread function (electromagnetic field distribution) of a focused laser beam with arbitrary wavefront. The code takes polarization into account
-- mie_calc: code that calculates the electromagnetic field distribution of a spherical particle at an arbitrary distance relative to a focused laser
+
+- *fast_psf_calc*: code that calculates the point spread function (electromagnetic field distribution) of a focused laser beam with arbitrary wavefront. The code takes polarization into account
+- *mie_calc*: code that calculates the electromagnetic field distribution of a spherical particle at an arbitrary distance relative to a focused laser
 
 All code is developed in-house at LUMICKS.
+
+
+## How to get started
+
+1. Create and activate a virtual environment. With conda:
+
+       $ conda create -n py-optics python=3.8
+       $ conda activate py-optics
+
+2. Clone the repository:
+
+       $ git clone https://github.com/lumicks/py-optics
+       $ cd py-optics
+
+3. Install the *pyoptics* package:
+
+       $ pip install -e .
+
+   Or, if you want to install the additional dependencies for the example Notebooks:
+
+       $ pip install -e .[examples]
+
+Example Jupyter Notebooks are available in the `examples` directory:
+
+4. Run the Notebook:
+
+       $ cd examples
+       $ jupyter notebook

--- a/examples/fast_psf_calc_benchmark.py
+++ b/examples/fast_psf_calc_benchmark.py
@@ -18,14 +18,9 @@
 import matplotlib.pyplot as plt
 import matplotlib
 import numpy as np
-import os, sys, inspect
 
 # %% jupyter={"source_hidden": true} tags=[]
-cmd_subfolder = os.path.realpath(os.path.abspath(os.path.join(os.path.split(
-    inspect.getfile( inspect.currentframe() ))[0],"..")))
-if cmd_subfolder not in sys.path:
-     sys.path.insert(0, cmd_subfolder)
-import psf_calc as psf
+from pyoptics import fast_psf_calc as psf
 
 # %% jupyter={"source_hidden": true} tags=[]
 font = {'family' : 'normal',

--- a/examples/mie_calc.py
+++ b/examples/mie_calc.py
@@ -8,16 +8,16 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.1
 #   kernelspec:
-#     display_name: Python 3.8 (XPython)
+#     display_name: Python 3
 #     language: python
-#     name: xpython
+#     name: python3
 # ---
 
 # %% tags=[]
 # %matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
-import mie_calc as mc
+from pyoptics import mie_calc as mc
 
 # %% [markdown]
 # # Examples of spherical particle in a focus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 41.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[metadata]
+name = pyoptics
+version = attr: pyoptics.__version__
+
+author = Robert J. Moerland
+author_email = r.moerland@lumicks.com
+
+url = https://github.com/lumicks/py-optics
+project_urls =
+    Source = https://github.com/lumicks/py-optics
+
+description = Computational code for nanophotonics
+long_description = file: README.md
+license = Other/Proprietary License
+
+keywords = nanophotonics
+classifiers =
+    License :: Other/Proprietary License
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Physics
+
+[options]
+python_requires = >=3.7
+install_requires =
+    matplotlib>=3.3.0
+    numpy>=1.19.2
+    scipy>=1.6
+    pyfftw>=0.12.0
+include_package_data = True
+package_dir =
+    =src
+packages = find:
+
+[options.extras_require]
+examples =
+    notebook>=6.0
+    jupytext>=1.5
+
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()

--- a/src/pyoptics/__init__.py
+++ b/src/pyoptics/__init__.py
@@ -1,0 +1,9 @@
+__title__ = 'pyoptics'
+__version__ = '0.1.0'
+
+__description__ = 'Computational code for nanophotonics'
+__url__ = 'https://github.com/lumicks/py-optics'
+
+__author__ = 'Robert J. Moerland'
+__email__ = 'r.moerland@lumicks.com'
+__copyright__ = 'Copyright (c) 2021 Robert J. Moerland, LUMICKS B.V.'

--- a/src/pyoptics/fast_psf_calc/czt.py
+++ b/src/pyoptics/fast_psf_calc/czt.py
@@ -1,32 +1,37 @@
+"""Chirp Z transforms"""
+
 import pyfftw
 import numpy as np
 
+
 def init_czt(x, M, w, a):
-    """init_czt(x, M, w, a): initialize auxilliary vectors that can be precomputed
-    in order to perform a chirp-z transform. Storing these vectors prevents having to
-    recalculate them on every function call, therefore speeding up the calculation if a 
-    transform is required on data of the same size as x repeatedly.
+    """Initialize auxilliary vectors that can be precomputed in order to perform a chirp-z
+    transform. Storing these vectors prevents having to recalculate them on every function
+    call, therefore speeding up the calculation if a transform is required on data of the
+    same size as x repeatedly.
 
-    :param x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
-    along the columns, compatible with MATLAB's implementation. Note that the data is
-    not actually transformed, but the dimensions are used to initialize the
-    auxilliary vectors.
-    :param M: Number of points to compute the chirp-z transform at
-    :param w: ratio between consecutive points on the complex plane.
-    :param a: The starting point on the complex plane of the transform.
-    Returns: an opaque tuple containing the auxilliary vectors.
+    Args:
+        x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
+            along the columns, compatible with MATLAB's implementation. Note that the data is
+            not actually transformed, but the dimensions are used to initialize the
+            auxilliary vectors.
+        M: Number of points to compute the chirp-z transform at
+        w: ratio between consecutive points on the complex plane.
+        a: The starting point on the complex plane of the transform.
 
+    Returns:
+        An opaque tuple containing the auxilliary vectors.
     """
      # Upconvert to make it a matrix to handle vectors and matrices the same way
     xshape = x.shape
     x = np.atleast_2d(x)
-    
+
     newshape = x.shape
     N = int(newshape[0])
     expand_shape = (1, *newshape[1:])
     tile_shape = [1] * (len(newshape)-1)
 
-    L = pyfftw.next_fast_len(M + N  -1)  # 1 << ((M + N - 1) - 1).bit_length() 
+    L = pyfftw.next_fast_len(M + N  -1)  # 1 << ((M + N - 1) - 1).bit_length()
 
     k = np.arange(np.max((M, N))).T
     ww = w**(k**2 / 2)
@@ -34,39 +39,40 @@ def init_czt(x, M, w, a):
     anww = an * ww[0:N]
     anww = anww.reshape((N, *tile_shape))
     anww = np.tile(anww, expand_shape)
-    
+
     pyfftw.interfaces.cache.enable()
-    
+
     v = np.zeros(L, dtype='complex128')
     v[0: M] = 1 / ww[0: M]
     v[(L - N + 1):L+1] = 1 / ww[1:N][::-1]
-    
+
     V = pyfftw.interfaces.numpy_fft.fft(v, L, axis=0)
     V = np.reshape(V, (L, *tile_shape))
     V = np.tile(V, expand_shape)
-    
+
     ww = ww.reshape((ww.shape[0], *tile_shape))
     ww = np.tile(ww[0:M], expand_shape)
-        
+
     return xshape, M, L, anww, V, ww
 
 
 def exec_czt(x, precomputed):
-    """g = exec_czt(x, precomputed): Calculate the chirp z transform of the
-    discrete series x, at discrete points defined by init_czt() and using the
-    precomputed auxilliary vectors for performance. This function performs nearly
-    no checks on the input data.
-    
+    """Calculate the chirp z transform of the discrete series x, at discrete points
+    defined by init_czt() and using the precomputed auxilliary vectors for performance.
+    This function performs nearly no checks on the input data.
+
     Tweaked implementation following Lawrence R. Rabiner, Ronald W. Schafer,
     and Charles M. Rader, "The chirp z-transform algorithm and its
     application," Bell Syst. Tech. J. 48, 1249-1292 (1969).
 
-    :param x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
-    along the columns, minimicking MATLAB's implementation.
-    :param precomputed: an opaque tuple with the necessary data to perform the transform,
-      obtained with init_czt()
-    Returns: the M-point chirp z transform
+    Args:
+        x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
+            along the columns, minimicking MATLAB's implementation.
+        precomputed: an opaque tuple with the necessary data to perform the transform,
+            obtained with init_czt()
 
+    Returns:
+        The M-point chirp z transform
     """
      # Upconvert to make it a matrix to handle vectors and matrices the same way
     x=np.atleast_2d(x)
@@ -76,7 +82,7 @@ def exec_czt(x, precomputed):
     Y = pyfftw.interfaces.numpy_fft.fft(y, L, axis=0)
 
     G = Y * V
-    
+
     g = pyfftw.interfaces.numpy_fft.ifft(G, L, axis=0)
     g = g[0:M] * ww
 
@@ -84,36 +90,39 @@ def exec_czt(x, precomputed):
         output = g.reshape((M,))
     else:
         output = g
-        
+
     return output
 
+
 def czt(x, M, w, a):
-    """g = czt(x, M, w, a): Calculate the chirp z transform of the discrete series x,
-    at discrete points on the complex plane defined by z = a * w**(-(0:M-1)).
-    
+    """Calculate the chirp z transform of the discrete series x, at discrete points
+    on the complex plane defined by z = a * w**(-(0:M-1)).
+
     Direct implementation following Lawrence R. Rabiner, Ronald W. Schafer,
     and Charles M. Rader, "The chirp z-transform algorithm and its
     application," Bell Syst. Tech. J. 48, 1249-1292 (1969).
 
-    :param x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
-    along the columns, compatible with MATLAB's implementation.
-    :param M: number of points to calculate the transform for.
-    :param w: ratio between consecutive points on the complex plane.
-    :param a: The starting point on the complex plane of the transform.
-    Returns: the M-point chirp z transform
+    Args:
+        x: vector or matrix of data. If x is a matrix, the chirp z transform is calculated
+            along the columns, compatible with MATLAB's implementation.
+        M: number of points to calculate the transform for.
+        w: ratio between consecutive points on the complex plane.
+        a: The starting point on the complex plane of the transform.
 
+    Returns:
+        The M-point chirp z transform.
     """
-    
+
     # Upconvert to make it a matrix to handle vectors and matrices the same way
     xshape=x.shape
     x=np.atleast_2d(x)
-    
+
     newshape = x.shape
     N = int(newshape[0])
     expand_shape = (1, *newshape[1:])
     tile_shape = [1] * (len(newshape)-1)
 
-    L = pyfftw.next_fast_len(M + N  -1)  # 1 << ((M + N - 1) - 1).bit_length() 
+    L = pyfftw.next_fast_len(M + N  -1)  # 1 << ((M + N - 1) - 1).bit_length()
 
     k = np.arange(np.max((M, N))).T
     ww = w**(k**2 / 2)
@@ -121,18 +130,18 @@ def czt(x, M, w, a):
     anww = an * ww[0:N]
     anww = anww.reshape((N, *tile_shape))
     y = np.tile(anww, expand_shape) * x
-    
+
     pyfftw.interfaces.cache.enable()
     Y = pyfftw.interfaces.numpy_fft.fft(y, L, axis=0, threads=2)
 
     v = np.zeros(L, dtype='complex128')
     v[0: M] = 1 / ww[0: M]
     v[(L - N + 1):L+1] = 1 / ww[1:N][::-1]
-    
+
     V = pyfftw.interfaces.numpy_fft.fft(v, L, axis=0)
     V = np.reshape(V, (L, *tile_shape))
     G = Y * np.tile(V, expand_shape)
-    
+
     g = pyfftw.interfaces.numpy_fft.ifft(G, L, axis=0, threads=2)
     ww = ww.reshape((ww.shape[0], *tile_shape))
     g = g[0:M] * np.tile(ww[0:M], expand_shape)
@@ -141,5 +150,5 @@ def czt(x, M, w, a):
         output = g.reshape((M,))
     else:
         output = g
-        
+
     return output

--- a/src/pyoptics/mie_calc/legendre.py
+++ b/src/pyoptics/mie_calc/legendre.py
@@ -1,22 +1,23 @@
+"""Legendre polynomials"""
+
 import numpy as np
 import scipy.special as sp
 import numpy.polynomial as npp
 
 
 def associated_legendre(n, x):
-    """associated_legendre(n, x): Return the 1st order (m == 1) of the 
-    associated Legendre polynomial of degree n, evaluated at x.
-    """
+    """Return the 1st order (m == 1) of the associated Legendre polynomial of degree n, evaluated at x"""
     orders = np.zeros(n+1)
     orders[n]=1
     c=npp.Legendre(npp.legendre.legder(orders))
     return -c(x) * np.sqrt(1 - x**2)
 
-def associated_legendre_dtheta(n, cos_theta, alp_pre=(None, None)):
-    """Evaluate the derivative of the associated legendre polynomial 
-    P_n^1(cos(theta)), of order 1 and degree n, to the variable theta, 
-    where cos_theta == cos(theta)."""
 
+def associated_legendre_dtheta(n, cos_theta, alp_pre=(None, None)):
+    """
+    Evaluate the derivative of the associated legendre polynomial P_n^1(cos(theta)), of
+    order 1 and degree n, to the variable theta, where cos_theta == cos(theta).
+    """
     if alp_pre[0] is None:
         alp = associated_legendre(n, cos_theta)
         if n > 1:
@@ -31,18 +32,18 @@ def associated_legendre_dtheta(n, cos_theta, alp_pre=(None, None)):
         else:
             # let it 'crash' on cos_theta == +/- 1, fix later
             with np.errstate(divide='ignore', invalid='ignore'):
-                result = (n * cos_theta * alp - (n + 1) * alp_1) / np.sqrt(1 - 
+                result = (n * cos_theta * alp - (n + 1) * alp_1) / np.sqrt(1 -
                         cos_theta**2)
 
     result[cos_theta == 1] = -n * (n + 1) / 2
     result[cos_theta == -1] = -(-1)**n * n * (n + 1) / 2
-    
+
     return result
 
 
 def associated_legendre_over_sin_theta(n, cos_theta, alp_pre=None):
     """Evaluate P_n^1(cos(theta))/sin(theta)"""
-    
+
     if alp_pre is None:
         alp = associated_legendre(n, cos_theta)
     else:


### PR DESCRIPTION
@rjmoerland Not sure how useful you find this, but this is an attempt to apply a "standard" directory layout to *py-optics*.

This is an attempt to make the *py-optics* project conform to Python
packaging standards ([0], [1], [2]):

- Add a `pyproject.toml` file. It doesn't do much at this point, besides
declaring its dependency on *setuptools* for building.

- Use a more standard directory layout, based on a `src/` root directory
containing the various packages ([1]). There are definitely other ways to
approach this, but the arguments in favor of a `src/` directory seem to
make sense. Example notebooks go into a top-level `examples/` directory.

- Use a `setup.cfg` file for declaring package metadata. We apparently
still need a stub `setup.py` file ([0]) to make it possible to use `pip
install -e .`.

- Move code into a package, with a top-level *pyoptics* package that
contains the other subpackages. The top-level *pyoptics* package
contains appropriate metadata, including a title, author, and a `0.1.0`
version number. Subpackages have their main code in the `__init__`
module (again, there are other ways to do this, but in this case it
seems sensible to do it this way).

- Apply uniform formatting of docstrings.

 [0]: https://snarky.ca/what-the-heck-is-pyproject-toml/
 [1]: https://hynek.me/articles/testing-packaging/
[2]:
https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html