### PR TITLE
Remove mkl FFT dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ python_requires = >=3.8
 install_requires =
     numpy>=1.19.2
     scipy>=1.6
-    mkl_fft>=1.3.0
     numba>=0.54.0rc1
 include_package_data = True
 package_dir =

--- a/src/lumicks/pyoptics/psf/czt.py
+++ b/src/lumicks/pyoptics/psf/czt.py
@@ -1,6 +1,6 @@
 """Chirp Z transforms"""
 
-from mkl_fft._numpy_fft import fft, ifft
+from scipy.fft import fft, ifft, next_fast_len
 import numpy as np
 
 def init_czt(x, M, w, a):
@@ -30,7 +30,7 @@ def init_czt(x, M, w, a):
     expand_shape = (1, *newshape[1:])
     tile_shape = [1] * (len(newshape)-1)
 
-    L =  1 << ((M + N - 1) - 1).bit_length()  # pyfftw.next_fast_len(M + N  -1)
+    L =  next_fast_len(M + N - 1)
 
     k = np.arange(np.max((M, N))).T
     ww = w**(k**2 / 2)
@@ -119,7 +119,7 @@ def czt(x, M, w, a):
     expand_shape = (1, *newshape[1:])
     tile_shape = [1] * (len(newshape)-1)
 
-    L = 1 << ((M + N - 1) - 1).bit_length()
+    L = next_fast_len(M + N - 1)
 
     k = np.arange(np.max((M, N))).T
     ww = w**(k**2 / 2)

--- a/tests/psf/test_czt_gaussian.py
+++ b/tests/psf/test_czt_gaussian.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing
 import pytest
 import lumicks.pyoptics.psf as psf
 


### PR DESCRIPTION
Remove this dependency for now. The version on Pypi seems to be stuck at 1.3.1, and we don't want to go through a manual installation process. We can look into pyFFTW, for example, if performance becomes an issue, but for now, we let scipy handle the platform-specific details. 